### PR TITLE
npmi: fix bugs for fetching runs from selector

### DIFF
--- a/tensorboard/webapp/plugins/npmi/data_source/npmi_data_source.ts
+++ b/tensorboard/webapp/plugins/npmi/data_source/npmi_data_source.ts
@@ -124,7 +124,7 @@ export class NpmiHttpServerDataSource implements NpmiDataSource {
         for (const run of Object.keys(annotations)) {
           for (const annotationIndex in annotations[run]) {
             const annotation = annotations[run][annotationIndex];
-            if (embeddings[run][annotationIndex]) {
+            if (embeddings[run] && embeddings[run][annotationIndex]) {
               embeddingData[annotation] = embeddings[run][annotationIndex];
             }
             const metricToDataElements = new Map<string, ValueData>();

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_container.ts
@@ -1,4 +1,3 @@
-import {combineLatest, forkJoin} from 'rxjs';
 /* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +15,7 @@ limitations under the License.
 import {Component, ChangeDetectionStrategy, Input} from '@angular/core';
 import {Store, select} from '@ngrx/store';
 import {State} from '../../../../../app_state';
-import {Observable} from 'rxjs';
+import {Observable, combineLatest} from 'rxjs';
 import {
   map,
   filter,
@@ -98,9 +97,11 @@ export class AnnotationContainer {
   readonly fetches$ = this.experimentIds$.pipe(
     filter((experimentIds) => Boolean(experimentIds)),
     switchMap((experimentIds) => {
-      return experimentIds!.map((experimentId) => {
-        return this.store.select(selectors.getRuns, {experimentId});
-      });
+      return combineLatest(
+        experimentIds!.map((experimentId) => {
+          return this.store.select(selectors.getRuns, {experimentId});
+        })
+      );
     }),
     startWith([]),
     tap((runMaps) => {

--- a/tensorboard/webapp/plugins/npmi/views/main/main_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/main/main_component.scss
@@ -47,6 +47,7 @@ limitations under the License.
 }
 
 .run-selector {
+  height: 100%;
   width: 100%;
 }
 


### PR DESCRIPTION
Two things:
1. embeddings can be empty and change to the data_source addresses the
issue where the plugin threw JavaScript exception for accessing [0] of
undefined.
2. switchMap expects a single observable to wait for. We were returning
an array of Observable which resulted in a wrong behavior. We fixed it
by wrapping it with `combineLatest`.
